### PR TITLE
Fix issue when using a 29 bits extended id

### DIFF
--- a/canard/hw/cantact.py
+++ b/canard/hw/cantact.py
@@ -1,7 +1,6 @@
 import serial
-import io
-
 from .. import can
+
 
 class CantactDev:
     def __init__(self, port):

--- a/canard/hw/socketcan.py
+++ b/canard/hw/socketcan.py
@@ -1,9 +1,9 @@
-import os
 import struct
 import socket
 import time
 
 from .. import can
+
 
 class SocketCanDev:
     def __init__(self, ndev):
@@ -23,12 +23,18 @@ class SocketCanDev:
         frame_size = struct.calcsize(frame_format)
 
         frame_raw = self.socket.recv(frame_size)
-        id, dlc, d0, d1, d2, d3, d4, d5, d6, d7 = struct.unpack(frame_format,
-                                                                frame_raw)
+        id_, dlc, d0, d1, d2, d3, d4, d5, d6, d7 = struct.unpack(frame_format,
+                                                                 frame_raw)
 
-        frame = can.Frame(id)
+        # adjust the id and set the extended id flag
+        is_extended = False
+        if id_ & 0x80000000:
+            id_ &= 0x7FFFFFFF
+            is_extended = True
+
+        frame = can.Frame(id_, is_extended_id=is_extended)
         frame.dlc = dlc
-        frame.data = [d0,d1,d2,d3,d4,d5,d6,d7]
+        frame.data = [d0, d1, d2, d3, d4, d5, d6, d7]
         frame.timestamp = time.time() - self.start_time
 
         return frame
@@ -37,8 +43,13 @@ class SocketCanDev:
         assert self.running, 'device not running'
         frame_format = "=IBBBBBBBBBBBB"
 
+        # set the extended bit if a extended id is used
+        id_ = frame.id
+        if frame.is_extended_id:
+            id_ |= 0x80000000
+
         data = frame.data
-        packet = struct.pack(frame_format, frame.id, frame.dlc,
-                    0xff, 0xff, 0xff, data[0], data[1], data[2], data[3], 
-                    data[4], data[5], data[6], data[7])
+        packet = struct.pack(frame_format, id_, frame.dlc, 0xff, 0xff, 0xff,
+                             data[0], data[1], data[2], data[3],
+                             data[4], data[5], data[6], data[7])
         self.socket.send(packet)


### PR DESCRIPTION
1.using intance variables instead of clas variables in Frame.
2.Fix: no attribute exception is raised when creating a frame with 29 bits extended id.
3.The extneded id flag is lost during transmission.
