### PR TITLE
Replace `None` with `0` in test frame data, fix `list.extend()` method typo in canard.can

### DIFF
--- a/canard/can.py
+++ b/canard/can.py
@@ -84,7 +84,7 @@ class Frame(object):
             assert isinstance(byte, int), 'CAN data must consist of bytes'
             assert byte >= 0 and byte <= 0xFF, 'CAN data must consist of bytes'
         # data is valid
-        self._data= value
+        self._data = value
 
     @property
     def frame_type(self):

--- a/canard/can.py
+++ b/canard/can.py
@@ -70,7 +70,7 @@ class Frame(object):
         # return bytes up to dlc length, pad with zeros
         data_len = min(self.dlc, len(self._data))
         result = self.data[:data_len]
-        result.extended([0] * (8 - data_len))
+        result.extend([0] * (8 - data_len))
         return result
 
     @data.setter
@@ -84,7 +84,7 @@ class Frame(object):
             assert isinstance(byte, int), 'CAN data must consist of bytes'
             assert byte >= 0 and byte <= 0xFF, 'CAN data must consist of bytes'
         # data is valid
-        self._data = value
+        self._data= value
 
     @property
     def frame_type(self):

--- a/canard/test/can_test.py
+++ b/canard/test/can_test.py
@@ -48,10 +48,10 @@ class CanTest(unittest.TestCase):
 
         self.frame.dlc = 3
         self.assertEqual(self.frame.data,
-                         [1, 2, 3, None, None, None, None, None])
+                         [1, 2, 3, 0, 0, 0, 0, 0])
         self.frame.dlc = 0
         self.assertEqual(self.frame.data,
-                         [None, None, None, None, None, None, None, None])
+                         [0, 0, 0, 0, 0, 0, 0, 0])
 
     def test_frame_type(self):
         # test invalid frame type causes error
@@ -74,7 +74,7 @@ class CanTest(unittest.TestCase):
     def test_init(self):
         frame = can.Frame(0x55, 6, [1,2,3,4,5,6], can.FrameType.ErrorFrame, True)
         self.assertEqual(frame.id, 0x55)
-        self.assertEqual(frame.data, [1,2,3,4,5,6,None,None])
+        self.assertEqual(frame.data, [1,2,3,4,5,6,0,0])
         self.assertEqual(frame.frame_type, can.FrameType.ErrorFrame)
         self.assertEqual(frame.is_extended_id, True)
 


### PR DESCRIPTION
1. In canard.test.can_test, `frame.data` should not have `None` type in its list. I replace `None` with `0`
2. A typo `result.extended' was found in canard.can,`result`is a`list`type, and the method name is supposed to be`extend`.
