### PR TITLE
Python3 fixes: Use connection.write('foo'.encode())

### DIFF
--- a/canard/hw/cantact.py
+++ b/canard/hw/cantact.py
@@ -7,18 +7,18 @@ class CantactDev:
         self.ser = serial.Serial(port)
 
     def start(self):
-        self.ser.write('O\r')
+        self.ser.write('O\r'.encode())
 
     def stop(self):
-        self.ser.write('C\r')
+        self.ser.write('C\r'.encode())
 
     def set_bitrate(self, bitrate):
         if bitrate == 125000:
-            self.ser.write('S0\r')
+            self.ser.write('S0\r'.encode())
         elif bitrate == 250000:
-            self.ser.write('S1\r')
+            self.ser.write('S1\r'.encode())
         elif bitrate == 500000:
-            self.ser.write('S2\r')
+            self.ser.write('S2\r'.encode())
         else:
             raise ValueError("Bitrate not supported")
 
@@ -55,4 +55,4 @@ class CantactDev:
         tx_str = tx_str + '\r'
 
         # send it
-        self.ser.write(tx_str)
+        self.ser.write(tx_str.encode())

--- a/examples/cantact.py
+++ b/examples/cantact.py
@@ -4,7 +4,7 @@ import sys
 
 dev = cantact.CantactDev(sys.argv[1])
 
-dev.ser.write('S0\r')
+dev.ser.write('S0\r'.encode())
 dev.start()
 count = 0
 while True:


### PR DESCRIPTION
PySerial running under Python 3 requires a bytestring be passed
to .write.
Curently, calls like connection.write('foo') are being used

This was the error:
$ sudo python3 cantact.py /dev/ttyACM0
Traceback (most recent call last):
  File "cantact.py", line 8, in <module>
    dev.start()
  File "/usr/lib/python3.4/site-packages/canard/hw/cantact.py", line 11, in start
    self.ser.write('O\r')
  File "/usr/lib/python3.4/site-packages/serial/serialposix.py", line 491, in write
    d = to_bytes(data)
  File "/usr/lib/python3.4/site-packages/serial/serialutil.py", line 76, in to_bytes
    b.append(item)  # this one handles int and str for our emulation and ints for Python 3.x
TypeError: an integer is required