### PR TITLE
Two issues / data getter

### DIFF
--- a/canard/can.py
+++ b/canard/can.py
@@ -69,8 +69,8 @@ class Frame(object):
     def data(self):
         # return bytes up to dlc length, pad with zeros
         data_len = min(self.dlc, len(self._data))
-        result = self.data[:data_len]
-        result.extended([0] * (8 - data_len))
+        result = self._data[:data_len]
+        result.extend([0] * (8 - data_len))
         return result
 
     @data.setter


### PR DESCRIPTION
There was an issue with an infinite recursion:  (see also _"Infinite recursion when sending frame #6"_)
result = self.data[... -> changed to  result = self._data[...

There is no extended
result.extended(... -> result.extend(...